### PR TITLE
Add Protovalidate support

### DIFF
--- a/quarkus-protobuf-demo/pom.xml
+++ b/quarkus-protobuf-demo/pom.xml
@@ -49,12 +49,17 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>4.33.1</version>
+            <version>4.33.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>4.33.1</version>
+            <version>4.33.2</version>
+        </dependency>
+        <dependency>
+            <groupId>build.buf</groupId>
+            <artifactId>protovalidate</artifactId>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -138,6 +143,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>build.buf</groupId>
+                        <artifactId>protovalidate</artifactId>
+                        <version>1.1.0</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/quarkus-protobuf-demo/src/main/java/com/example/ProtobufMessageBodyReader.java
+++ b/quarkus-protobuf-demo/src/main/java/com/example/ProtobufMessageBodyReader.java
@@ -6,12 +6,17 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
+import build.buf.protovalidate.ValidationResult;
+import build.buf.protovalidate.Validator;
+import build.buf.protovalidate.ValidatorFactory;
+import build.buf.protovalidate.exceptions.ValidationException;
 import com.google.protobuf.Message;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.Provider;
 
@@ -22,6 +27,8 @@ import org.jboss.logging.Logger;
 public class ProtobufMessageBodyReader implements MessageBodyReader<Message> {
 
     private static final Logger LOG = Logger.getLogger(ProtobufMessageBodyReader.class);
+
+    private final Validator validator = ValidatorFactory.newBuilder().build();
 
     @Override
     public boolean isReadable(Class<?> type, Type genericType,
@@ -36,16 +43,39 @@ public class ProtobufMessageBodyReader implements MessageBodyReader<Message> {
             Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, String> headers,
             InputStream inputStream)
-            throws IOException, WebApplicationException {
+            throws WebApplicationException {
+
+        Message message;
+
+        // Parse a message
         LOG.infof("ProtobufMessageBodyReader.readFrom: parsing %s from InputStream", type.getSimpleName());
         try {
             Method parseFrom = type.getMethod("parseFrom", InputStream.class);
-            Message message = (Message) parseFrom.invoke(null, inputStream);
+            message = (Message) parseFrom.invoke(null, inputStream);
             LOG.infof("ProtobufMessageBodyReader.readFrom: successfully parsed %s", type.getSimpleName());
-            return message;
         } catch (Exception e) {
             LOG.errorf(e, "ProtobufMessageBodyReader.readFrom: failed to parse %s", type.getSimpleName());
             throw new WebApplicationException("Failed to parse protobuf message", e);
         }
+
+        // Validate it
+        try {
+            ValidationResult validationResult  = validator.validate(message);
+            if ( !validationResult.isSuccess() ) {
+                LOG.infof("ProtobufMessageBodyReader.readFrom: validation failed for %s: %s",
+                    type.getSimpleName(), validationResult.getViolations());
+
+                Response response = Response.status(Response.Status.BAD_REQUEST)
+                        .entity(validationResult.toProto().toByteArray())
+                        .type("application/x-protobuf")
+                        .build();
+
+                throw new WebApplicationException("Validation failed", response);
+            }
+        } catch (ValidationException e) {
+            LOG.errorf(e, "ProtobufMessageBodyReader.readFrom: failed to validate %s", type.getSimpleName());
+            throw new WebApplicationException("Failed to validate protobuf message", e);
+        }
+        return message;
     }
 }

--- a/quarkus-protobuf-demo/src/main/proto/user.proto
+++ b/quarkus-protobuf-demo/src/main/proto/user.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package com.example;
 
+import "buf/validate/validate.proto";
+
 option java_multiple_files = true;
 option java_package = "com.example.proto";
 option java_outer_classname = "UserProto";
@@ -20,6 +22,15 @@ message UserList {
 }
 
 message CreateUserRequest {
-  string name = 1;
-  string email = 2;
+  string name = 1 [
+    (buf.validate.field).string = {
+      min_len: 1,
+      max_len: 250,
+    }
+  ];
+  string email = 2 [
+    (buf.validate.field).string = {
+      email: true,
+    }
+  ];
 }


### PR DESCRIPTION
Hi Markus! This PR started as a comment on your [Substack post about ditching JSON for speed](https://www.the-main-thread.com/p/protobuf-quarkus-rest-api-tutorial-java) - I 100% agree on the efficiency of Protobuf and wanted to add how schema-first development with Proto can go further.

One of my favorite ways to demonstrate this is with [Protovalidate](https://protovalidate.com/): instead of writing the same validation rules at multiple layers, we can often move most rules, even multi-field rules via Google CEL, into our Proto. It's basically like have annotation-style Java bean validation in the .proto instead of Java source, making it cross-platform:

```protobuf
message CreateUserRequest {
  string name = 1 [
    (buf.validate.field).string = {
      min_len: 1,
      max_len: 250,
    }
  ];
  string email = 2 [
    (buf.validate.field).string = {
      email: true,
    }
  ];
}
```

Then, if we send a `CreateUserRequest` that doesn't have a name or has a bad email address, we can return a Protobuf message that describes all of the field errors (see the new `testInvalidUser`).

A PR communicated it most effectively, so I created this diff just to show how it could extend your demo. I don't expect you'll merge it, but if you'd like to work together on a follow-up post, let me know!